### PR TITLE
Replace toml with tomllib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Install Python dependencies
-      run: |
-        python -m pip install toml
     - name: Install rust
       run: |
         rustup show

--- a/generate_commands.py
+++ b/generate_commands.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2023 Nitrokey GmbH
 # SPDX-License-Identifier: LGPL-3.0-only
 
-import toml
 import sys
+import tomllib
 
 def capitilize_first(name):
     name
@@ -84,7 +84,8 @@ if len(sys.argv) != 3:
     exit(1)
 
 outfile = open(sys.argv[2], "w")
-data = toml.load(sys.argv[1])
+with open(sys.argv[1], "rb") as infile:
+    data = tomllib.load(infile)
 
 # REUSE-IgnoreStart
 outfile.write("// Copyright (C) 2023 Nitrokey GmbH\n")

--- a/src/se05x/commands.toml
+++ b/src/se05x/commands.toml
@@ -89,7 +89,7 @@ p2 = "P2_DEFAULT"
 
 [scp_external_authenticate.payload]
 then = [
-  { name = "host_cryptogram", type = "[u8; 8]" }
+  { name = "host_cryptogram", type = "[u8; 8]" },
   { name = "mac", type = "[u8; 8]" }
 ]
 


### PR DESCRIPTION
The Python 3.11 standard library provides tomllib for parsing TOML files.  As even Debian stable ships Python 3.11, we should be fine with using it instead of the third-party toml dependency.