### PR TITLE
Fix crash on frame larger than max frame size

### DIFF
--- a/src/t1.rs
+++ b/src/t1.rs
@@ -475,6 +475,11 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> T1oI2C<Twi, D> {
                 return Err(Error::ReceptionBuffer);
             }
 
+            if len as usize > MAX_FRAME_DATA_LEN {
+                error!("Frame too large");
+                return Err(Error::ReceptionBuffer);
+            }
+
             let mut data_buf = [0; MAX_FRAME_DATA_LEN];
             let current_buf = &mut buffer[written..][..len as usize];
             let data_buf = &mut data_buf[..len as _];


### PR DESCRIPTION
Found while looking for a source of https://github.com/Nitrokey/nitrokey-3-firmware/issues/474

I don't think this is the root cause, since this would only trigger if the se050 sends badly formatted data.
Nonetheless in this case it is better to error than to crash.