### PR TITLE
fix: Force extended length apdu for export object

### DIFF
--- a/generate_commands.py
+++ b/generate_commands.py
@@ -110,6 +110,7 @@ for command, v in data.items():
     p2 = v["p2"]
     p2_val = p2
     le = v.get("le", 0)
+    force_extended = v.get("force_extended", False)
 
     payload_has_lifetime = False
     for _, a in flatten(v["payload"].items()):
@@ -203,6 +204,8 @@ for command, v in data.items():
     slice_val = "&[" + slice_val_inner + "]"
 
     command_builder = f'CommandBuilder::new({cla}, {ins}, {p1_val}, {p2_val}, __data, {le})'
+    if force_extended:
+        command_builder = f'{command_builder}.force_extended()'
 
     outfile.write(f'impl{payload_lifetime} DataSource for {name}{payload_lifetime} {{\n')
     outfile.write('    fn len(&self) -> usize {\n')

--- a/src/se05x/commands.rs
+++ b/src/se05x/commands.rs
@@ -1623,7 +1623,8 @@ impl DataSource for ExportObject {
         let object_id = &Tlv::new(TAG_1, self.object_id);
         let rsa_key_component = &Tlv::new(TAG_2, self.rsa_key_component);
         let __data: &[&dyn DataSource] = &[object_id, rsa_key_component];
-        let command = CommandBuilder::new(NO_SM_CLA, INS_READ, P1_DEFAULT, P2_EXPORT, __data, 256);
+        let command = CommandBuilder::new(NO_SM_CLA, INS_READ, P1_DEFAULT, P2_EXPORT, __data, 256)
+            .force_extended();
         command.len()
     }
     fn is_empty(&self) -> bool {
@@ -1636,7 +1637,8 @@ impl<W: Writer> DataStream<W> for ExportObject {
         let object_id = &Tlv::new(TAG_1, self.object_id);
         let rsa_key_component = &Tlv::new(TAG_2, self.rsa_key_component);
         let __data: &[&dyn DataStream<W>] = &[object_id, rsa_key_component];
-        let command = CommandBuilder::new(NO_SM_CLA, INS_READ, P1_DEFAULT, P2_EXPORT, __data, 256);
+        let command = CommandBuilder::new(NO_SM_CLA, INS_READ, P1_DEFAULT, P2_EXPORT, __data, 256)
+            .force_extended();
         command.to_writer(writer)
     }
 }

--- a/src/se05x/commands.toml
+++ b/src/se05x/commands.toml
@@ -335,6 +335,7 @@ ins = "INS_READ"
 p1 = "P1_DEFAULT"
 p2 = "P2_EXPORT"
 le = "256"
+force_extended = true
 
 [export_object.payload]
 TAG_1 = { name = "object_id", type = "ObjectId" }


### PR DESCRIPTION
Basically the SE050 will never respond with more than 256 bytes when responding to a short apdu This was not an issue previously since we only ever exported keys that were smaller than that.

We cannot really dynamically force the extended apdu based on the key type because this information is not available in the command.