### PR TITLE
Update typed-builder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ nrf-hal-common = { version = "0.15.0", optional = true }
 rand = { version = "0.8.5", optional = true, default-features = false }
 serde = { version = "1.0.185", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.14", optional = true, default-features = false }
-typed-builder = { version = "0.18.0", optional = true }
+typed-builder = { version = "0.20.0", optional = true }
 
 [features]
 default = ["aes-session"]

--- a/generate_commands.py
+++ b/generate_commands.py
@@ -167,13 +167,13 @@ for command, v in data.items():
 
     if "maybe_p1_mask" in v:
         a = v["maybe_p1_mask"]
-        outfile.write("    #[cfg_attr(feature = \"builder\", builder(default, setter(strip_option)))]\n")
+        outfile.write(f'    #[cfg_attr(feature = "builder", builder(default, setter(strip_option(fallback = {a["name"] + "_opt"}))))]\n')
         outfile.write(f'    pub {a["name"]}: Option<{a["type"]}>,\n')
         pre_ins += f'        let p1: u8 = self.{a["name"]}.map(|v| v | {p1_val} ).unwrap_or({p1});\n'
         p1_val = "p1"
     if "maybe_p2_mask" in v:
         a = v["maybe_p2_mask"]
-        outfile.write("    #[cfg_attr(feature = \"builder\", builder(default, setter(strip_option)))]\n")
+        outfile.write(f'    #[cfg_attr(feature = "builder", builder(default, setter(strip_option(fallback = {a["name"] + "_opt"}))))]\n')
         outfile.write(f'    pub {a["name"]}: Option<{a["type"]}>,\n')
         pre_ins += f'        let p2: u8 = self.{a["name"]}.map(|v| v | {p2_val} ).unwrap_or({p2});\n'
         p2_val = "p2"

--- a/src/se05x/commands.rs
+++ b/src/se05x/commands.rs
@@ -463,7 +463,7 @@ pub struct WriteEcKey<'data> {
     pub transient: bool,
     #[cfg_attr(feature = "builder", builder(default))]
     pub is_auth: bool,
-    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option(fallback = key_type_opt))))]
     pub key_type: Option<P1KeyType>,
     /// Serialized to TLV tag [`TAG_POLICY`]()
     #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
@@ -570,9 +570,9 @@ pub struct WriteRsaKey<'data> {
     pub transient: bool,
     #[cfg_attr(feature = "builder", builder(default))]
     pub is_auth: bool,
-    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option(fallback = key_type_opt))))]
     pub key_type: Option<P1KeyType>,
-    #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]
+    #[cfg_attr(feature = "builder", builder(default, setter(strip_option(fallback = key_format_opt))))]
     pub key_format: Option<RsaFormat>,
     /// Serialized to TLV tag [`TAG_POLICY`]()
     #[cfg_attr(feature = "builder", builder(default, setter(strip_option)))]


### PR DESCRIPTION
This now allows using a better syntax for optional values.