### PR TITLE
Add a test run to the CI workflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ typed-builder = { version = "0.20.0", optional = true }
 
 [features]
 default = ["aes-session"]
-serde = ["dep:serde", "serde_bytes"]
+serde = ["dep:serde", "dep:serde_bytes"]
 builder = ["typed-builder"]
 
 log-all = []

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,12 @@ lint: src/se05x/commands.rs verify-commands
 	cargo clippy --features lpc55-v0.4 --target thumbv8m.main-none-eabi
 	cargo doc --features aes-session,builder,serde --no-deps
 
+.PHONY: test
+test:
+	cargo t
+	cargo t --features builder,serde_bytes
+	cargo t --no-default-features
+
 README.md: src/lib.rs Makefile
 	# REUSE-IgnoreStart
 	echo '<!-- Copyright (C) 2023 Nitrokey GmbH -->' > README.md

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,10 @@ test:
 	cargo t --features builder,serde_bytes
 	cargo t --no-default-features
 
+.PHONY: semver-checks
+semver-checks:
+	 cargo semver-checks --only-explicit-features --features aes-session,builder,lpc55
+
 README.md: src/lib.rs Makefile
 	# REUSE-IgnoreStart
 	echo '<!-- Copyright (C) 2023 Nitrokey GmbH -->' > README.md

--- a/generate_commands.py
+++ b/generate_commands.py
@@ -143,7 +143,6 @@ for command, v in data.items():
         response_lifetime = "<'data>"
         response_lifetime_inferred = "<'_>"
 
-
     outfile.write("#[derive(Clone, Debug, PartialEq, Eq)]\n")
     outfile.write("#[cfg_attr(feature = \"builder\", derive(typed_builder::TypedBuilder))]\n")
     outfile.write(f'pub struct {name}{payload_lifetime} {{\n')
@@ -225,7 +224,6 @@ for command, v in data.items():
     outfile.write('        false\n')
     outfile.write('    }\n')
     outfile.write("}\n")
-
 
     outfile.write(f'impl<W: Writer> DataStream<W> for {name}{payload_lifetime_inferred} {{\n')
     outfile.write('    fn to_writer(&self, writer: &mut W) -> Result<(), <W as iso7816::command::Writer>::Error> {\n')

--- a/src/se05x.rs
+++ b/src/se05x.rs
@@ -92,7 +92,7 @@ pub trait Se05XCommand<W: Writer>: DataStream<W> {
     type Response<'a>: Se05XResponse<'a>;
 }
 
-impl<W: Writer, C: Se05XCommand<W>> Se05XCommand<W> for &'_ C {
+impl<W: Writer, C: Se05XCommand<W>> Se05XCommand<W> for &C {
     type Response<'a> = C::Response<'a>;
 }
 


### PR DESCRIPTION
This PR also fixes clippy warnings and adds a simplified test target for cargo `semver-check`  because `--all-features` does not work for the HAL dependencies.