### PR TITLE
Add support for embedded-hal v1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ bitflags = "2.3.2"
 cmac = { version = "0.7.2", optional = true }
 crc16 = "0.4"
 delog = "0.1"
-embedded-hal = "0.2.7"
+embedded-hal-v0_2_7 = { package = "embedded-hal", version = "0.2.7", optional = true }
+embedded-hal-v1_0 = { package = "embedded-hal", version = "1.0", optional = true }
+
 heapless = "0.7"
 hex-literal = "0.4.1"
 iso7816 = "0.1.1"
@@ -33,6 +35,8 @@ typed-builder = { version = "0.20.0", optional = true }
 default = ["aes-session"]
 serde = ["dep:serde", "serde_bytes"]
 builder = ["typed-builder"]
+"embedded-hal-v0.2.7" = ["dep:embedded-hal-v0_2_7"]
+"embedded-hal-v1.0" = ["dep:embedded-hal-v1_0"]
 
 log-all = []
 log-debug = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ log-warn = []
 log-error = []
 log-none = []
 
-nrf = ["nrf-hal-common"]
-lpc55 = ["lpc55-v0.3"]
+nrf = ["nrf-hal-common", "dep:embedded-hal-v0_2_7"]
+lpc55 = ["lpc55-v0.3", "dep:embedded-hal-v0_2_7"]
 "lpc55-v0.3" = ["dep:lpc55-hal"]
 "lpc55-v0.4" = ["dep:lpc55-hal-04"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ log-warn = []
 log-error = []
 log-none = []
 
-nrf = ["nrf-hal-common", "dep:embedded-hal-v0_2_7"]
-lpc55 = ["lpc55-v0.3", "dep:embedded-hal-v0_2_7"]
+nrf = ["nrf-hal-common", "embedded-hal-v0_2_7"]
+lpc55 = ["lpc55-v0.3", "embedded-hal-v0_2_7"]
 "lpc55-v0.3" = ["dep:lpc55-hal"]
 "lpc55-v0.4" = ["dep:lpc55-hal-04"]
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,17 @@ Architecture
 This driver communicates with the se05x over the T=1 protocol over I2C, as described in [UM11225](https://www.nxp.com/webapp/Download?colCode=UM11225).
 
 To do so and be compatible with most embedded controlers, it depends on the I2C [Read](https://docs.rs/embedded-hal/latest/embedded_hal/blocking/i2c/trait.Read.html) and [Write](https://docs.rs/embedded-hal/latest/embedded_hal/blocking/i2c/trait.Write.html) from [embedded-hal](https://docs.rs/embedded-hal/latest/embedded_hal).
-However these traits do not expose the enough, as the T=1 protocol requires detecting I2C NACKs, which are not exposed in this protocol.
+
+#### Embedded HAL v0.2
+
+The traits do not expose the protocol enough, as the T=1 protocol requires detecting I2C NACKs, which are not exposed in this version.
 
 Nacks are exposed in the `Error` types for each `HAL` crate. As such an extension to the embedded-hal traits is defined as `I2CErrorNack`, exposing the missing information.
 It is implemented for the NRF and LPC55 Hals in `src/t1/i2cimpl.rs`, gated by the features `nrf` and `lpc55` respectively.
 
-This may not be necessary with future releases of `embedded-hal`, which [adds the missing information](https://docs.rs/embedded-hal/1.0.0-alpha.11/embedded_hal/i2c/enum.ErrorKind.html).
+#### Embedded HAL v1.0
+
+This version exposes the required I2C NACKs. There is no need to use the `nrf` and `lpc55` features.
 
 ### Iso7816
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ It is implemented for the NRF and LPC55 Hals in `src/t1/i2cimpl.rs`, gated by th
 
 This may not be necessary with future releases of `embedded-hal`, which [adds the missing information](https://docs.rs/embedded-hal/1.0.0-alpha.11/embedded_hal/i2c/enum.ErrorKind.html).
 
-
 ### Iso7816
 
 This driver uses the [`iso7816`](https://docs.rs/iso7816/latest/iso7816/) crate to implement serialization of APDUs.

--- a/src/doc_utils.rs
+++ b/src/doc_utils.rs
@@ -2,8 +2,8 @@
 //
 // Not included in the crate, meant to be used with `include!`
 
-use embedded_hal::blocking::delay::DelayUs;
-use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
+use se05x::embedded_hal::i2c::{Read, Write, WriteRead};
+use se05x::embedded_hal::Delay;
 
 #[derive(Debug)]
 pub struct DummyI2c;
@@ -41,7 +41,7 @@ impl WriteRead<u8> for DummyI2c {
 #[derive(Debug)]
 pub struct DummyDelay;
 
-impl DelayUs<u32> for DummyDelay {
+impl Delay for DummyDelay {
     fn delay_us(&mut self, _: u32) {
         unimplemented!()
     }
@@ -52,7 +52,7 @@ pub fn get_i2c() -> impl se05x::t1::I2CForT1 {
     DummyI2c
 }
 
-pub fn get_delay() -> impl DelayUs<u32> {
+pub fn get_delay() -> impl Delay {
     unimplemented!();
     DummyDelay
 }

--- a/src/embedded_hal.rs
+++ b/src/embedded_hal.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2023 Nitrokey GmbH
+// SPDX-License-Identifier: LGPL-3.0-only
+
 /// wrapper struct for embedded_hal v0.2.7 that implements the required internal traits
 pub struct Hal027<T>(pub T);
 

--- a/src/embedded_hal.rs
+++ b/src/embedded_hal.rs
@@ -1,0 +1,134 @@
+// traits to be used internally for I2C write
+pub mod i2c {
+    use crate::embedded_hal;
+
+    pub trait Write<A> {
+        type Error;
+
+        fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error>;
+    }
+
+    #[cfg(feature = "embedded-hal-v0.2.7")]
+    impl<T, A> Write<A> for T
+    where
+        T: embedded_hal_v0_2_7::blocking::i2c::Write,
+    {
+        type Error = T::Error;
+
+        fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), T::Error> {
+            self.write(address, bytes)
+        }
+    }
+
+    #[cfg(feature = "embedded-hal-v1.0")]
+    impl<T, A> Write<A> for T
+    where
+        T: embedded_hal_v1_0::i2c::I2c,
+    {
+        type Error = T::Error;
+
+        fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), T::Error> {
+            self.write(address, bytes)
+        }
+    }
+
+    pub trait Read<A> {
+        type Error;
+
+        fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error>;
+    }
+
+    #[cfg(feature = "embedded-hal-v0.2.7")]
+    impl<T, A> Read<A> for T
+    where
+        T: embedded_hal_v0_2_7::blocking::i2c::Read,
+    {
+        type Error = T::Error;
+
+        fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), T::Error> {
+            self.read(address, buffer)
+        }
+    }
+
+    #[cfg(feature = "embedded-hal-v1.0")]
+    impl<T, A> Read<A> for T
+    where
+        T: embedded_hal_v1_0::i2c::I2c,
+    {
+        type Error = T::Error;
+
+        fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), T::Error> {
+            self.read(address, buffer)
+        }
+    }
+
+    pub trait WriteRead<A> {
+        type Error;
+
+        fn write_read(
+            &mut self,
+            address: u8,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), Self::Error>;
+    }
+
+    #[cfg(feature = "embedded-hal-v0.2.7")]
+    impl<T, A> WriteRead<A> for T
+    where
+        T: embedded_hal_v0_2_7::blocking::i2c::WriteRead,
+    {
+        type Error = T::Error;
+
+        fn write_read(
+            &mut self,
+            address: u8,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), T::Error> {
+            self.write_read(address, bytes, buffer)
+        }
+    }
+
+    #[cfg(feature = "embedded-hal-v1.0")]
+    impl<T, A> WriteRead<A> for T
+    where
+        T: embedded_hal_v1_0::i2c::I2c,
+    {
+        type Error = T::Error;
+
+        fn write_read(
+            &mut self,
+            address: u8,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), T::Error> {
+            self.write_read(address, bytes, buffer)
+        }
+    }
+}
+
+// trait to be used internally for Delay
+pub trait Delay {
+    fn delay_us(&mut self, us: u32);
+}
+
+#[cfg(feature = "embedded-hal-v0.2.7")]
+impl<T> Delay for T
+where
+    T: embedded_hal_v0_2_7::blocking::delay::DelayUs<u32>,
+{
+    fn delay_us(&mut self, us: u32) {
+        self.delay_us(us);
+    }
+}
+
+#[cfg(feature = "embedded-hal-v1.0")]
+impl<T> Delay for T
+where
+    T: embedded_hal_v1_0::delay::DelayNs,
+{
+    fn delay_us(&mut self, us: u32) {
+        self.delay_us(us);
+    }
+}

--- a/src/embedded_hal.rs
+++ b/src/embedded_hal.rs
@@ -1,7 +1,11 @@
+/// wrapper struct for embedded_hal v0.2.7 that implements the required internal traits
+pub struct Hal027<T>(pub T);
+
+/// wrapper struct for embedded_hal v1.0.0 that implements the required internal traits
+pub struct Hal10<T>(pub T);
+
 // traits to be used internally for I2C write
 pub mod i2c {
-    use crate::embedded_hal;
-
     pub trait Write<A> {
         type Error;
 
@@ -9,26 +13,26 @@ pub mod i2c {
     }
 
     #[cfg(feature = "embedded-hal-v0.2.7")]
-    impl<T, A> Write<A> for T
+    impl<T, A> Write<A> for super::Hal027<T>
     where
         T: embedded_hal_v0_2_7::blocking::i2c::Write,
     {
         type Error = T::Error;
 
         fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), T::Error> {
-            self.write(address, bytes)
+            self.0.write(address, bytes)
         }
     }
 
     #[cfg(feature = "embedded-hal-v1.0")]
-    impl<T, A> Write<A> for T
+    impl<T, A> Write<A> for super::Hal10<T>
     where
         T: embedded_hal_v1_0::i2c::I2c,
     {
         type Error = T::Error;
 
         fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), T::Error> {
-            self.write(address, bytes)
+            self.0.write(address, bytes)
         }
     }
 
@@ -39,26 +43,26 @@ pub mod i2c {
     }
 
     #[cfg(feature = "embedded-hal-v0.2.7")]
-    impl<T, A> Read<A> for T
+    impl<T, A> Read<A> for super::Hal027<T>
     where
         T: embedded_hal_v0_2_7::blocking::i2c::Read,
     {
         type Error = T::Error;
 
         fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), T::Error> {
-            self.read(address, buffer)
+            self.0.read(address, buffer)
         }
     }
 
     #[cfg(feature = "embedded-hal-v1.0")]
-    impl<T, A> Read<A> for T
+    impl<T, A> Read<A> for super::Hal10<T>
     where
         T: embedded_hal_v1_0::i2c::I2c,
     {
         type Error = T::Error;
 
         fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), T::Error> {
-            self.read(address, buffer)
+            self.0.read(address, buffer)
         }
     }
 
@@ -74,7 +78,7 @@ pub mod i2c {
     }
 
     #[cfg(feature = "embedded-hal-v0.2.7")]
-    impl<T, A> WriteRead<A> for T
+    impl<T, A> WriteRead<A> for super::Hal027<T>
     where
         T: embedded_hal_v0_2_7::blocking::i2c::WriteRead,
     {
@@ -86,12 +90,12 @@ pub mod i2c {
             bytes: &[u8],
             buffer: &mut [u8],
         ) -> Result<(), T::Error> {
-            self.write_read(address, bytes, buffer)
+            self.0.write_read(address, bytes, buffer)
         }
     }
 
     #[cfg(feature = "embedded-hal-v1.0")]
-    impl<T, A> WriteRead<A> for T
+    impl<T, A> WriteRead<A> for super::Hal10<T>
     where
         T: embedded_hal_v1_0::i2c::I2c,
     {
@@ -103,7 +107,7 @@ pub mod i2c {
             bytes: &[u8],
             buffer: &mut [u8],
         ) -> Result<(), T::Error> {
-            self.write_read(address, bytes, buffer)
+            self.0.write_read(address, bytes, buffer)
         }
     }
 }
@@ -114,21 +118,21 @@ pub trait Delay {
 }
 
 #[cfg(feature = "embedded-hal-v0.2.7")]
-impl<T> Delay for T
+impl<T> Delay for Hal027<T>
 where
     T: embedded_hal_v0_2_7::blocking::delay::DelayUs<u32>,
 {
     fn delay_us(&mut self, us: u32) {
-        self.delay_us(us);
+        self.0.delay_us(us);
     }
 }
 
 #[cfg(feature = "embedded-hal-v1.0")]
-impl<T> Delay for T
+impl<T> Delay for Hal10<T>
 where
     T: embedded_hal_v1_0::delay::DelayNs,
 {
     fn delay_us(&mut self, us: u32) {
-        self.delay_us(us);
+        self.0.delay_us(us);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ extern crate delog;
 delog::generate_macros!();
 
 mod macros;
+pub mod embedded_hal;
 
 pub mod se05x;
 pub mod t1;

--- a/src/se05x.rs
+++ b/src/se05x.rs
@@ -5,7 +5,7 @@ use core::{array::TryFromSliceError, convert::Infallible, fmt::Debug};
 
 use bitflags::bitflags;
 use delog::hexstr;
-use embedded_hal::blocking::delay::DelayUs;
+use crate::embedded_hal::Delay;
 use hex_literal::hex;
 use iso7816::{
     command::{
@@ -98,7 +98,7 @@ impl<'b, W: Writer, C: Se05XCommand<W>> Se05XCommand<W> for &'b C {
 
 pub const APP_ID: [u8; 0x10] = hex!("A0000003965453000000010300000000");
 
-impl<Twi: I2CForT1, D: DelayUs<u32>> Se05X<Twi, D> {
+impl<Twi: I2CForT1, D: Delay> Se05X<Twi, D> {
     pub fn new(twi: Twi, se_address: u8, delay: D) -> Self {
         Self {
             t1: T1oI2C::new(twi, se_address, delay),

--- a/src/se05x.rs
+++ b/src/se05x.rs
@@ -3,9 +3,9 @@
 
 use core::{array::TryFromSliceError, convert::Infallible, fmt::Debug};
 
+use crate::embedded_hal::Delay;
 use bitflags::bitflags;
 use delog::hexstr;
-use crate::embedded_hal::Delay;
 use hex_literal::hex;
 use iso7816::{
     command::{
@@ -97,6 +97,40 @@ impl<W: Writer, C: Se05XCommand<W>> Se05XCommand<W> for &C {
 }
 
 pub const APP_ID: [u8; 0x10] = hex!("A0000003965453000000010300000000");
+
+#[cfg(feature = "embedded-hal-v0.2.7")]
+impl<M, N, E> Se05X<crate::embedded_hal::Hal027<M>, crate::embedded_hal::Hal027<N>>
+where
+    N: embedded_hal_v0_2_7::blocking::delay::DelayUs<u32>,
+    M: embedded_hal_v0_2_7::blocking::i2c::Write<Error = E>
+        + embedded_hal_v0_2_7::blocking::i2c::Read<Error = E>
+        + embedded_hal_v0_2_7::blocking::i2c::WriteRead<Error = E>,
+    E: crate::t1::I2CErrorNack,
+{
+    pub fn new_hal_027(twi: M, se_address: u8, delay: N) -> Self {
+        Self::new(
+            crate::embedded_hal::Hal027(twi),
+            se_address,
+            crate::embedded_hal::Hal027(delay),
+        )
+    }
+}
+
+#[cfg(feature = "embedded-hal-v1.0")]
+impl<M, N, E> Se05X<crate::embedded_hal::Hal10<M>, crate::embedded_hal::Hal10<N>>
+where
+    N: embedded_hal_v1_0::delay::DelayNs,
+    M: embedded_hal_v1_0::i2c::I2c<Error = E>,
+    E: crate::t1::I2CErrorNack,
+{
+    pub fn new_hal_10(twi: M, se_address: u8, delay: N) -> Self {
+        Self::new(
+            crate::embedded_hal::Hal10(twi),
+            se_address,
+            crate::embedded_hal::Hal10(delay),
+        )
+    }
+}
 
 impl<Twi: I2CForT1, D: Delay> Se05X<Twi, D> {
     pub fn new(twi: Twi, se_address: u8, delay: D) -> Self {

--- a/src/t1.rs
+++ b/src/t1.rs
@@ -386,6 +386,40 @@ pub enum DataReceived {
 
 const DEFAULT_RETRY_COUNT: u32 = 1024;
 
+#[cfg(feature = "embedded-hal-v0.2.7")]
+impl<M, N, E> T1oI2C<crate::embedded_hal::Hal027<M>, crate::embedded_hal::Hal027<N>>
+where
+    N: embedded_hal_v0_2_7::blocking::delay::DelayUs<u32>,
+    M: embedded_hal_v0_2_7::blocking::i2c::Write<Error = E>
+        + embedded_hal_v0_2_7::blocking::i2c::Read<Error = E>
+        + embedded_hal_v0_2_7::blocking::i2c::WriteRead<Error = E>,
+    E: I2CErrorNack,
+{
+    pub fn new_hal_027(twi: M, se_address: u8, delay: N) -> Self {
+        Self::new(
+            crate::embedded_hal::Hal027(twi),
+            se_address,
+            crate::embedded_hal::Hal027(delay),
+        )
+    }
+}
+
+#[cfg(feature = "embedded-hal-v1.0")]
+impl<M, N, E> T1oI2C<crate::embedded_hal::Hal10<M>, crate::embedded_hal::Hal10<N>>
+where
+    N: embedded_hal_v1_0::delay::DelayNs,
+    M: embedded_hal_v1_0::i2c::I2c<Error = E>,
+    E: I2CErrorNack,
+{
+    pub fn new_hal_10(twi: M, se_address: u8, delay: N) -> Self {
+        Self::new(
+            crate::embedded_hal::Hal10(twi),
+            se_address,
+            crate::embedded_hal::Hal10(delay),
+        )
+    }
+}
+
 impl<Twi: I2CForT1, D: Delay> T1oI2C<Twi, D> {
     pub fn new(twi: Twi, se_address: u8, delay: D) -> Self {
         // Default MPOT value.
@@ -810,7 +844,6 @@ impl<'writer, Twi: I2CForT1, D: Delay> FrameSender<'writer, Twi, D> {
         Ok(())
     }
 }
-
 
 impl<'writer, Twi: I2CForT1, D: Delay> Writer for FrameSender<'writer, Twi, D> {
     type Error = Error;

--- a/src/t1/i2cimpl.rs
+++ b/src/t1/i2cimpl.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Nitrokey GmbH
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#[cfg(feature = "nrf")]
+#[cfg(all(feature = "nrf", feature = "embedded-hal-v0.2.7"))]
 mod nrf52832 {
     use crate::t1::I2CErrorNack;
 
@@ -17,7 +17,7 @@ mod nrf52832 {
     }
 }
 
-#[cfg(feature = "lpc55-v0.3")]
+#[cfg(all(feature = "lpc55-v0.3", feature = "embedded-hal-v0.2.7"))]
 mod lpc55_03 {
     use crate::t1::I2CErrorNack;
 
@@ -33,7 +33,7 @@ mod lpc55_03 {
     }
 }
 
-#[cfg(feature = "lpc55-v0.4")]
+#[cfg(all(feature = "lpc55-v0.4", feature = "embedded-hal-v0.2.7"))]
 mod lpc55_04 {
     use crate::t1::I2CErrorNack;
 
@@ -46,5 +46,25 @@ mod lpc55_04 {
         fn is_data_nack(&self) -> bool {
             matches!(self, Error::NackData)
         }
+    }
+}
+
+#[cfg(feature = "embedded-hal-v1.0")]
+impl crate::t1::I2CErrorNack for embedded_hal_v1_0::i2c::ErrorKind {
+    fn is_address_nack(&self) -> bool {
+        matches!(
+            self,
+            embedded_hal_v1_0::i2c::ErrorKind::NoAcknowledge(
+                embedded_hal_v1_0::i2c::NoAcknowledgeSource::Address
+            )
+        )
+    }
+    fn is_data_nack(&self) -> bool {
+        matches!(
+            self,
+            embedded_hal_v1_0::i2c::ErrorKind::NoAcknowledge(
+                embedded_hal_v1_0::i2c::NoAcknowledgeSource::Data
+            )
+        )
     }
 }

--- a/src/t1/i2cimpl.rs
+++ b/src/t1/i2cimpl.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023 Nitrokey GmbH
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#[cfg(all(feature = "nrf", feature = "embedded-hal-v0.2.7"))]
+#[cfg(feature = "nrf")]
 mod nrf52832 {
     use crate::t1::I2CErrorNack;
 
@@ -17,7 +17,7 @@ mod nrf52832 {
     }
 }
 
-#[cfg(all(feature = "lpc55-v0.3", feature = "embedded-hal-v0.2.7"))]
+#[cfg(feature = "lpc55-v0.3")]
 mod lpc55_03 {
     use crate::t1::I2CErrorNack;
 
@@ -33,7 +33,7 @@ mod lpc55_03 {
     }
 }
 
-#[cfg(all(feature = "lpc55-v0.4", feature = "embedded-hal-v0.2.7"))]
+#[cfg(feature = "lpc55-v0.4")]
 mod lpc55_04 {
     use crate::t1::I2CErrorNack;
 


### PR DESCRIPTION
As discussed in a [previous pull request](https://github.com/Nitrokey/se05x/pull/21).

> This crate is built first to be used in the Nitrokey 3 firmware, which is still using embedded-hal 0.2, so we don't plan on dropping support for embedded-hal 0.2 in this crate until we chose to dedicate time to migrate the firmware and all its dependencies to the updated versions.
>
> However this crate's dependency on embedded-hal is rather simple since it only depends on the I2C and DelayUs traits.
> 
> We might accept a PR that adds support for both using this approach:
> 
> Add news traits for Se05x I2C and Delay.
> Behind feature flags (embedded-hal-1.0.0 and embedded-hal-0.2.7), add blanket impls for the traits, so that both version could be used downstream.