### PR TITLE
Simplify embedded-hal v1.0 error handling types

### DIFF
--- a/src/se05x.rs
+++ b/src/se05x.rs
@@ -117,11 +117,10 @@ where
 }
 
 #[cfg(feature = "embedded-hal-v1.0")]
-impl<M, N, E> Se05X<crate::embedded_hal::Hal10<M>, crate::embedded_hal::Hal10<N>>
+impl<M, N> Se05X<crate::embedded_hal::Hal10<M>, crate::embedded_hal::Hal10<N>>
 where
     N: embedded_hal_v1_0::delay::DelayNs,
-    M: embedded_hal_v1_0::i2c::I2c<Error = E>,
-    E: crate::t1::I2CErrorNack,
+    M: embedded_hal_v1_0::i2c::I2c,
 {
     pub fn new_hal_10(twi: M, se_address: u8, delay: N) -> Self {
         Self::new(

--- a/src/t1/i2cimpl.rs
+++ b/src/t1/i2cimpl.rs
@@ -48,23 +48,3 @@ mod lpc55_04 {
         }
     }
 }
-
-#[cfg(feature = "embedded-hal-v1.0")]
-impl crate::t1::I2CErrorNack for embedded_hal_v1_0::i2c::ErrorKind {
-    fn is_address_nack(&self) -> bool {
-        matches!(
-            self,
-            embedded_hal_v1_0::i2c::ErrorKind::NoAcknowledge(
-                embedded_hal_v1_0::i2c::NoAcknowledgeSource::Address
-            )
-        )
-    }
-    fn is_data_nack(&self) -> bool {
-        matches!(
-            self,
-            embedded_hal_v1_0::i2c::ErrorKind::NoAcknowledge(
-                embedded_hal_v1_0::i2c::NoAcknowledgeSource::Data
-            )
-        )
-    }
-}


### PR DESCRIPTION
The embedded-hal v1.0 was also relying on the dedicated error type introduced to be able to handle NACKs. I removed it because it is not needed.