### PR TITLE
Update lpc55-hal to v0.5 and release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Unreleased
 
+-
+
+## [v0.4.0][] (2026-03-20)
+
 - Add the `lpc55-v0.5` feature and remove the `lpc55-v0.3` and `lpc55-v0.4` features
+
+[v0.4.0]: https://github.com/Nitrokey/se05x/releases/tag/v0.4.0
 
 ## [v0.3.1][] (2025-10-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ SPDX-License-Identifier: CC0-1.0
 
 ## Unreleased
 
-## [v0.3.1][] (2025-10-14)
+- Add the `lpc55-v0.5` feature and remove the `lpc55-v0.3` and `lpc55-v0.4` features
 
+## [v0.3.1][] (2025-10-14)
 
 - Update type-builder to 0.23
 - Close sessions after failed authentication attempt ([#35][])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "se05x"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Nitrokey GmbH <info@nitrokey.com>"]
 
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ embedded-hal-v1_0 = { package = "embedded-hal", version = "1.0", optional = true
 heapless = "0.9"
 hex-literal = "0.4.1"
 iso7816 = "0.2.0"
-lpc55-hal = { version = "0.3.0", optional = true }
-lpc55-hal-04 = { package = "lpc55-hal", version = "0.4.0", optional = true }
+lpc55-hal-05 = { package = "lpc55-hal", version = "0.5.0", optional = true }
 nrf-hal-common = { version = "0.15.0", optional = true }
 rand = { version = "0.8.5", optional = true, default-features = false }
 serde = { version = "1.0.185", default-features = false, features = ["derive"], optional = true }
@@ -47,13 +46,9 @@ log-error = []
 log-none = []
 
 nrf = ["nrf-hal-common", "embedded-hal-v0.2.7"]
-"lpc55-v0.3" = ["dep:lpc55-hal", "embedded-hal-v0.2.7"]
-"lpc55-v0.4" = ["dep:lpc55-hal-04", "embedded-hal-v0.2.7"]
+"lpc55-v0.5" = ["dep:lpc55-hal-05", "embedded-hal-v0.2.7"]
 
 aes-session = ["aes", "cmac", "rand"]
 
 [package.metadata.docs.rs]
 features = ["aes-session", "builder", "serde"]
-
-[patch.crates-io]
-lpc55-hal = { git = "https://github.com/Nitrokey/lpc55-hal", tag = "v0.3.0-nitrokey.2" }

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ check: src/se05x/commands.rs
 	cargo c --features builder,embedded-hal-v1.0
 	cargo c --features builder,embedded-hal-v0.2.7,embedded-hal-v1.0
 	cargo c --features nrf,nrf-hal-common/52840 --target thumbv7em-none-eabihf
-	cargo c --features lpc55-v0.3 --target thumbv8m.main-none-eabi
-	cargo c --features lpc55-v0.4 --target thumbv8m.main-none-eabi
+	cargo c --features lpc55-v0.5 --target thumbv8m.main-none-eabi
 
 
 .PHONY: lint
@@ -35,8 +34,7 @@ lint: src/se05x/commands.rs verify-commands
 	cargo clippy --features builder,embedded-hal-v0.2.7
 	cargo clippy --features builder,embedded-hal-v1.0
 	cargo clippy --features nrf,nrf-hal-common/52840 --target thumbv7em-none-eabihf
-	cargo clippy --features lpc55-v0.3 --target thumbv8m.main-none-eabi
-	cargo clippy --features lpc55-v0.4 --target thumbv8m.main-none-eabi
+	cargo clippy --features lpc55-v0.5 --target thumbv8m.main-none-eabi
 	cargo doc --features aes-session,builder,serde --no-deps
 
 .PHONY: test
@@ -48,8 +46,7 @@ test:
 .PHONY: semver-checks
 semver-checks:
 	 cargo semver-checks --only-explicit-features --features aes-session,builder,embedded-hal-v0.2.7,embedded-hal-v1.0
-	 cargo semver-checks --only-explicit-features --features aes-session,builder,lpc55-v0.3
-	 cargo semver-checks --only-explicit-features --features aes-session,builder,lpc55-v0.4
+	 cargo semver-checks --only-explicit-features --features aes-session,builder,lpc55-v0.5
 	 # TODO: re-introduce once https://github.com/obi1kenobi/cargo-semver-checks/issues/717 is fixed
 	 # Or script our way around it
 	 # cargo semver-checks --only-explicit-features --features aes-session,builder,nrf,nrf-hal-common/52840

--- a/src/t1/i2cimpl.rs
+++ b/src/t1/i2cimpl.rs
@@ -17,27 +17,11 @@ mod nrf52832 {
     }
 }
 
-#[cfg(feature = "lpc55-v0.3")]
-mod lpc55_03 {
+#[cfg(feature = "lpc55-v0.5")]
+mod lpc55_05 {
     use crate::t1::I2CErrorNack;
 
-    use lpc55_hal::drivers::i2c::Error;
-
-    impl I2CErrorNack for Error {
-        fn is_address_nack(&self) -> bool {
-            matches!(self, Error::NackAddress)
-        }
-        fn is_data_nack(&self) -> bool {
-            matches!(self, Error::NackData)
-        }
-    }
-}
-
-#[cfg(feature = "lpc55-v0.4")]
-mod lpc55_04 {
-    use crate::t1::I2CErrorNack;
-
-    use lpc55_hal_04::drivers::i2c::Error;
+    use lpc55_hal_05::drivers::i2c::Error;
 
     impl I2CErrorNack for Error {
         fn is_address_nack(&self) -> bool {


### PR DESCRIPTION
Unfortunately, we cannot keep support for old lpc55-hal versions because we cannot depend on multiple cortex-m-rt versions.